### PR TITLE
gulp対応

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,3 @@
-var Varline = function () {
-
-};
-
+var Varline = require(__dirname + '/lib/Varline');
 Varline.gulp = require(__dirname + '/lib/gulp');
-
 module.exports = Varline;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+var Varline = function () {
+
+};
+
+Varline.gulp = require(__dirname + '/lib/gulp');
+
+module.exports = Varline;

--- a/lib/Varline.js
+++ b/lib/Varline.js
@@ -1,0 +1,80 @@
+var fs = require('fs');
+var path = require('path');
+
+var async = require('async');
+
+var scriptMatchList = require('./scriptMatchList');
+var bowerPathList = require('../lib/bowerPathList');
+var pathToConcated = require('../lib/pathToConcated');
+
+var Varline = function (opts) {
+    opts = opts || {};
+    this.loadPath = opts.loadPath || [];
+    this.wrap = !!opts.wrap;
+    this.alias = opts.alias || {};
+    this.locate = opts.locate || {};
+    this.ignoredNames = opts.ignore || [];
+    this.forcedNames = opts.forced || [];
+
+    this.pathsForName = scriptMatchList({
+        loadPath: this.loadPath,
+        locate: this.locate
+    });
+};
+
+Varline.prototype.loadBowerComponents = function (callback) {
+    bowerPathList(process.cwd(), function (err, list) {
+        if (err) {
+            callback(err);
+            return;
+        }
+
+        var pathsForName = this.pathsForName;
+        for (var i in list) {
+            pathsForName[i] = list[i];
+        }
+        this.pathsForName = pathsForName;
+
+        callback();
+    }.bind(this));
+};
+
+Varline.prototype.resolve = function (name, callback) {
+    var pathsForName = this.pathsForName;
+    var ignoredNames = this.ignoredNames;
+    var forcedNames = this.forcedNames;
+    var alias = this.alias;
+
+    if (!pathsForName[name]) {
+        callback(name + ' is not found on src.');
+        return;
+    }
+
+    var vars = pathToConcated({
+        scriptName: name,
+        pathsForName: pathsForName,
+        ignoredNames: ignoredNames,
+        alias: alias
+    });
+    forcedNames.forEach(function (n) {
+        vars.unshift(n);
+    });
+
+    var sources = [];
+    vars.forEach(function (name) {
+        sources.push(fs.readFileSync(pathsForName[name], 'utf8'));
+        // TODO: encodingは念のため引数にしたい
+    });
+
+    if (this.wrap) {
+        sources.unshift('(function () {');
+        sources.push('})();');
+    }
+
+    callback(null, {
+        vars: vars,
+        source: sources.join('\n')
+    });
+};
+
+module.exports = Varline;

--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -1,0 +1,22 @@
+var gutil = require('gulp-util');
+var through = require('through2');
+
+module.exports = function (option) {
+
+    function transform (file, encoding, callback) {
+        var result = '';
+
+        var output = new gutil.File({
+            cwd: file.cwd,
+            base: file.base,
+            path: file.base + 'test.js'
+        });
+
+        output.contents = new Buffer(result);
+        this.push(output);
+        
+        callback();
+    }
+
+    return through.obj(transform, null);
+};

--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -1,7 +1,11 @@
 var gutil = require('gulp-util');
 var through = require('through2');
 
-module.exports = function (option) {
+module.exports = function (opts) {
+    opts = opts || {};
+    var loadPath = opts.loadPath || [];
+    var wrap = !!opts.wrap;
+    var alias = opts.alias || {};
 
     function transform (file, encoding, callback) {
         var result = '';
@@ -9,7 +13,7 @@ module.exports = function (option) {
         var output = new gutil.File({
             cwd: file.cwd,
             base: file.base,
-            path: file.base + 'test.js'
+            path: file.path
         });
 
         output.contents = new Buffer(result);

--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -1,11 +1,10 @@
 var gutil = require('gulp-util');
 var through = require('through2');
 
+var Varline = require(__dirname + '/Varline');
+
 module.exports = function (opts) {
-    opts = opts || {};
-    var loadPath = opts.loadPath || [];
-    var wrap = !!opts.wrap;
-    var alias = opts.alias || {};
+    var varline = new Varline(opts);
 
     function transform (file, encoding, callback) {
         var result = '';

--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -1,3 +1,5 @@
+var path = require('path');
+
 var gutil = require('gulp-util');
 var through = require('through2');
 
@@ -7,18 +9,35 @@ module.exports = function (opts) {
     var varline = new Varline(opts);
 
     function transform (file, encoding, callback) {
-        var result = '';
+        var name = path.basename(file.path, '.js');
 
-        var output = new gutil.File({
-            cwd: file.cwd,
-            base: file.base,
-            path: file.path
-        });
+        varline.loadBowerComponents(function (err) {
+            // bower componentsの取得に失敗しても、候補に追加されないだけなので、
+            // 全体の処理は気にせず進める
 
-        output.contents = new Buffer(result);
-        this.push(output);
-        
-        callback();
+            // var destPath = path.join(dest, name + '.js');
+            varline.resolve(name, function (err, result) {
+                if (err) {
+                    console.error('[error] %s', name);
+                    console.error(err.toString());
+                    callback();
+                    return;
+                }
+                console.log('[success] %s', name);
+                console.log(result.vars);
+
+                var output = new gutil.File({
+                    cwd: file.cwd,
+                    base: file.base,
+                    path: file.path
+                });
+
+                output.contents = new Buffer(result.source);
+                this.push(output);
+                
+                callback();
+            }.bind(this));
+        }.bind(this));
     }
 
     return through.obj(transform, null);

--- a/lib/gulp.js
+++ b/lib/gulp.js
@@ -5,6 +5,8 @@ var through = require('through2');
 
 var Varline = require(__dirname + '/Varline');
 
+var PLUGIN_NAME = 'varline';
+
 module.exports = function (opts) {
     var varline = new Varline(opts);
 
@@ -15,16 +17,18 @@ module.exports = function (opts) {
             // bower componentsの取得に失敗しても、候補に追加されないだけなので、
             // 全体の処理は気にせず進める
 
-            // var destPath = path.join(dest, name + '.js');
             varline.resolve(name, function (err, result) {
                 if (err) {
-                    console.error('[error] %s', name);
-                    console.error(err.toString());
+                    this.emit('error', new gutil.PluginError(
+                        PLUGIN_NAME,
+                        err,
+                        { showStack: true }
+                    ));
                     callback();
                     return;
                 }
-                console.log('[success] %s', name);
-                console.log(result.vars);
+
+                gutil.log(PLUGIN_NAME, '`' + name + '`', result.vars);
 
                 var output = new gutil.File({
                     cwd: file.cwd,

--- a/lib/pathToConcated.js
+++ b/lib/pathToConcated.js
@@ -3,10 +3,14 @@ var grunt = require('grunt'),
     extractDepVars = require('extract_dep_vars');
 
 var pathToConcated = function (opts) {
-    var scriptName = opts.scriptName || {};
+    var scriptName = opts.scriptName;
     var pathsForName = opts.pathsForName || {};
     var ignoredNames = opts.ignoredNames || {};
     var alias = opts.alias || {};
+
+    if (!scriptName) {
+        throw new Error('"scriptName" is required');
+    }
 
     var scriptPath = pathsForName[scriptName];
     var names = [scriptName];

--- a/lib/pathToConcated.js
+++ b/lib/pathToConcated.js
@@ -3,26 +3,17 @@ var grunt = require('grunt'),
     extractDepVars = require('extract_dep_vars');
 
 var pathToConcated = function (opts) {
-    var scriptName = opts.scriptName;
-    var pathsForName = opts.pathsForName;
-    var ignoredNames = opts.ignoredNames;
-    var alias = opts.alias;
-
+    var scriptName = opts.scriptName || {};
+    var pathsForName = opts.pathsForName || {};
+    var ignoredNames = opts.ignoredNames || {};
+    var alias = opts.alias || {};
 
     var scriptPath = pathsForName[scriptName];
-
-    // console.log('[load] %s', scriptName);
-
     var names = [scriptName];
-
-    // console.log(' - src path: %s', scriptPath);
-
     var dependencies = extractDepVars(grunt.file.read(scriptPath));
-    // console.log(' - extract dep vars', dependencies);
 
     dependencies.forEach(function (depName) {
         while (alias[depName]) {
-            // console.log('[alias: %s -> %s]', depName, alias[depName]);
             depName = alias[depName];
         }
 
@@ -31,7 +22,6 @@ var pathToConcated = function (opts) {
         }
 
         if (!pathsForName[depName]) {
-            // console.error('[not found (%s)]', depName);
             return;
         }
 
@@ -42,7 +32,6 @@ var pathToConcated = function (opts) {
             alias: alias
         });
 
-        // console.log(' - union: %s + %s', moduleVars, names);
         names = _.union(moduleVars, names);
     });
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "resolve js dependencies and concat.",
   "main": "index.js",
   "dependencies": {
-    "grunt": "~0.4.1",
-    "extract_dep_vars": "0.0.4",
-    "bower_resolve": "~0.1.3",
-    "async": "~0.2.9",
+    "async": "0.*",
+    "extract_dep_vars": "0.*",
+    "bower_resolve": "0.*",
+    "grunt": "0.4.*",
     "through2": "0.*",
     "gulp-util": "3.*"
   },
@@ -16,11 +16,10 @@
     "url": "git://github.com/fnobi/grunt-auto-deps.git"
   },
   "keywords": [
-    "gruntplugin"
+    "gruntplugin", "gulpplugin"
   ],
   "author": "Fujisawa Shin",
   "license": "BSD",
-  "gitHead": "b239e08dd984459a5870244e3eeae100685affe6",
   "devDependencies": {
     "grunt-release": "~0.5.1"
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "grunt-auto-deps",
   "version": "0.5.0",
   "description": "resolve js dependencies and concat.",
+  "main": "index.js",
   "dependencies": {
     "grunt": "~0.4.1",
     "extract_dep_vars": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "grunt": "~0.4.1",
     "extract_dep_vars": "0.0.4",
     "bower_resolve": "~0.1.3",
-    "async": "~0.2.9"
+    "async": "~0.2.9",
+    "through2": "0.*",
+    "gulp-util": "3.*"
   },
   "repository": {
     "type": "git",

--- a/tasks/auto_deps.js
+++ b/tasks/auto_deps.js
@@ -1,94 +1,52 @@
-module.exports = function (grunt) {
-    var taskName        = 'auto_deps',
-        taskDescription = 'resolve js dependency and concat automatically.',
+var path = require('path');
+var async = require('async');
 
-        path = require('path'),
-        async = require('async'),
-        pathToConcated = require('../lib/pathToConcated'),
-        scriptMatchList = require('../lib/scriptMatchList'),
-        bowerPathList = require('../lib/bowerPathList');
-        _ = grunt.util._;
+module.exports = function (grunt) {
+    var Varline = require(__dirname + '/../lib/Varline');
+
+    var taskName = 'auto_deps';
+    var taskDescription = 'resolve js dependency and concat automatically.';
 
     grunt.file.defaultEncoding = 'utf8';
 
     grunt.registerMultiTask(taskName, taskDescription, function () {
-        var target = this.target,
-            config = grunt.config(taskName)[target],
+        var target = this.target;
+        var config = grunt.config(taskName)[target];
+        var scripts = config.scripts || [];
+        var dest = config.dest || 'js';
+        var done = this.async();
 
-            // config parameters
-            loadPath = config.loadPath || ['src/js/*.js', 'src/js/**/*.js'],
-            scripts = config.scripts || [],
-            locate = config.locate || {},
-            alias = config.alias || {},
-            ignoredNames = config.ignore || [],
-            forceddNames = config.forced || [],
-            dest = config.dest || 'js',
-            wrap = config.wrap ? true : false,
+        var varline = new Varline(config);
 
-            done = this.async();
+        varline.loadBowerComponents(function (err) {
+            // bower componentsの取得に失敗しても、候補に追加されないだけなので、
+            // 全体の処理は気にせず進める
 
-        var pathsForName = scriptMatchList({
-            loadPath: loadPath,
-            locate: locate
-        });
-
-        async.series([function (next) {
-            bowerPathList(process.cwd(), function (err, list) {
-                if (err) {
-                    // bower componentsの取得に失敗しても、候補に失敗するだけなので、
-                    // 全体の処理は気にせず進める
-                    return next();
-                }
-
-                for (var i in list) {
-                    pathsForName[i] = list[i];
-                }
-                next();
-            });
-        }, function (next) {
-            scripts.forEach(function (name) {
+            async.each(scripts, function (name, next) {
                 var destPath = path.join(dest, name + '.js');
-
-                // console.log('[script: %s]', name);
-                // console.log(' - dest path: %s', destPath);
-
-                if (!pathsForName[name]) {
-                    console.error('%s is not found on src.', name);
-                    return;
-                }
-
-                var vars = pathToConcated({
-                    scriptName: name,
-                    pathsForName: pathsForName,
-                    ignoredNames: ignoredNames,
-                    alias: alias
+                varline.resolve(name, function (err, result) {
+                    if (err) {
+                        console.error('[error] %s', destPath);
+                        console.error(err.toString());
+                        next();
+                        return;
+                    }
+                    console.log('[success] %s', destPath);
+                    console.log(result.vars);
+                    grunt.file.write(destPath, result.source);
+                    next();
                 });
-                var sources = [];
-
-                forceddNames.forEach(function (n) {
-                    vars.unshift(n);
-                });
-
-                console.log('[write] %s (%s)', destPath, vars.join(', '));
-
-                vars.forEach(function (name) {
-                    sources.push(grunt.file.read(pathsForName[name]));
-                });
-
-                if (wrap) {
-                    // console.log('[wrap]');
-                    sources.unshift('(function () {');
-                    sources.push('})();');
-                }
-
-                grunt.file.write(destPath, sources.join('\n'));
-            });
-            next();
-        }], function (err) {
-            if (err) {
-                throw new Error(err);
-            }
-            done();
+            }, done);            
         });
     });
 };
+
+
+
+
+
+
+
+
+
+

--- a/tasks/auto_deps.js
+++ b/tasks/auto_deps.js
@@ -1,17 +1,17 @@
 var path = require('path');
 var async = require('async');
 
+var Varline = require(__dirname + '/../lib/Varline');
+
+var TASK_NAME = 'auto_deps';
+var TASK_DESCRIPTION = 'resolve js dependency and concat automatically.';
+
 module.exports = function (grunt) {
-    var Varline = require(__dirname + '/../lib/Varline');
-
-    var taskName = 'auto_deps';
-    var taskDescription = 'resolve js dependency and concat automatically.';
-
     grunt.file.defaultEncoding = 'utf8';
 
-    grunt.registerMultiTask(taskName, taskDescription, function () {
+    grunt.registerMultiTask(TASK_NAME, TASK_DESCRIPTION, function () {
         var target = this.target;
-        var config = grunt.config(taskName)[target];
+        var config = grunt.config(TASK_NAME)[target];
         var scripts = config.scripts || [];
         var dest = config.dest || 'js';
         var done = this.async();


### PR DESCRIPTION
- **grunt:** `/task`に置いたjsファイルが、そのままタスク名になるしくみ
- **gulp:** 何かしら、`through2`オブジェクトを返す関数であればpipeできる

そんな感じなので共存可能。
